### PR TITLE
More function support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ concatenation).
 
     inc(1)
 
-Function application also looks the same as in Python. There's currently no way
-to define functions in GCL, but you can invoke functions passed in from the
-external environment.
+Function application also looks the same as in Python.
 
     inc 1
 
@@ -84,6 +82,13 @@ put a space between the function and the argument.
     }
 
     that_foo = tuple.foo;
+
+To create a function in GCL use the lambda syntax:
+
+    fn = lambda x, y, z: x + y * z;
+    result = fn(1, 2, 3)  # 7
+
+You can also add more functions by passing in an Environment to loads.
 
 Periods are used to dereference tuples.
 

--- a/gcl/functions.py
+++ b/gcl/functions.py
@@ -1,5 +1,6 @@
 """GCL standard library functions."""
 
+import functools
 from os import path
 import gcl
 
@@ -53,6 +54,20 @@ def fmt(str, args=None, env=None):
   return str.format(**proxies)
 
 
+def map_wrapper(fn, lst, env=None):
+  if isinstance(fn, EnvironmentFunction):
+    fn = functools.partial(fn, env=env)
+
+  return list(map(fn, lst))
+
+
+def filter_wrapper(fn, lst, env=None):
+  if isinstance(fn, EnvironmentFunction):
+    fn = functools.partial(fn, env=env)
+
+  return list(filter(fn, lst))
+
+
 class EnvironmentFunction(object):
   """Wrapper class for a special function that can use the env."""
   def __init__(self, fn):
@@ -65,8 +80,10 @@ class EnvironmentFunction(object):
 builtin_functions = {
     'eager': eager,
     'path_join': path.join,
-    'fmt': EnvironmentFunction(fmt)
-    }
+    'fmt': EnvironmentFunction(fmt),
+    'map': EnvironmentFunction(map_wrapper),
+    'filter': EnvironmentFunction(filter_wrapper),
+}
 
 
 # Binary operators, by precedence level
@@ -74,6 +91,7 @@ binary_operators = [
     {
       '*': lambda x, y: x * y,
       '/': lambda x, y: x / y,
+      '%': lambda x, y: x % y,
     }, {
       '+': lambda x, y: x + y,
       '-': lambda x, y: x - y,

--- a/gcl/util.py
+++ b/gcl/util.py
@@ -309,7 +309,7 @@ class JSONLoader(object):
     self.cache = gcl.Cache()
     self.filter_fn = filter_fn or no_filter
 
-  def __call__(self, current_file, rel_path):
+  def __call__(self, current_file, rel_path, env=None):
     nice_path, full_path = self.fs.resolve(current_file, rel_path)
 
     if path.splitext(nice_path)[1] == '.json':
@@ -317,7 +317,7 @@ class JSONLoader(object):
       do_load = lambda: self.filter_fn(nice_path, json.loads(self.fs.load(full_path)))
     else:
       # Load as GCL
-      do_load = lambda: gcl.loads(self.fs.load(full_path), filename=nice_path, loader=self)
+      do_load = lambda: gcl.loads(self.fs.load(full_path), filename=nice_path, loader=self, env=env)
     return self.cache.get(full_path, do_load)
 
 

--- a/test_functions.py
+++ b/test_functions.py
@@ -32,3 +32,18 @@ class TestStringInterpolation(unittest.TestCase):
     y = fmt 'Hi {things.foo}'
     """)
     self.assertEquals('Hi FOO', x['y'])
+
+  def testMap(self):
+    x = gcl.loads("""
+    lst = [1, 2];
+    y = map(lambda x: {hello = x}, lst)
+    """)
+    self.assertEquals(1, x['y'][0]['hello'])
+    self.assertEquals(2, x['y'][1]['hello'])
+
+  def testFilter(self):
+    x = gcl.loads("""
+    lst = [1, 2, 3];
+    y = filter(lambda x: x % 2 == 0, lst)
+    """)
+    self.assertEquals([2], x['y'])


### PR DESCRIPTION
This adds syntax for lambda x, y, z: expr type of expression. This can be used to create functions in GCL. Unfortunately to resolve ambiguity this removes support for ':' in tuple keys.
Also adds map() and filter() support, which can be used as a primitive form of loops.
Also adds support for the modulo (%) operator.
Also fixes a bug where a custom env wouldn't be propagated to includes.
